### PR TITLE
Current clipboard content appends to imgurbash2 output when using xsel

### DIFF
--- a/imgurbash2
+++ b/imgurbash2
@@ -152,7 +152,7 @@ function upload_images() {
 
 	# copy the URLs to the clipboard (if the user has xsel or xclip installed)
 	if [ $DISPLAY ]; then
-		{ type xsel >/dev/null 2>/dev/null && echo -n $clip | xsel --clipboard; } \
+		{ type xsel >/dev/null 2>/dev/null && echo -n $clip | xsel --input --clipboard; } \
 			|| { type xclip >/dev/null 2>/dev/null && echo -n $clip | xclip -sel "clip"; } \
 			|| echo "Haven't copied to the clipboard:  no xsel or xclip" >&2
 	else


### PR DESCRIPTION
As `man xsel` says, if standard output is not a terminal the current selection is output.
I use text file as output for imgurbash2 (and xsel version 1.2.0)
To reproduce the issue:

``` bash
echo -n 'some clipboard content' | xsel --clipboard
imgurbash2 http://i.imgur.com/CYYsfmD.png > /tmp/output.txt
cat /tmp/output.txt
```

> http://i.imgur.com/xus5IRy.png (Delete Hash = J0eHEjRYZdGhora)
> some clipboard content

and also

``` bash
xsel --clipboard --output
```

> some clipboard content

instead of imgur url
