### PR TITLE
Enable logging by default and change log path

### DIFF
--- a/imgurbash2
+++ b/imgurbash2
@@ -431,7 +431,7 @@ setup() {
 		echo >> "$CONF_FILE"
 
 		echo "# Enable/Disable information being logged within a log file" >> "$CONF_FILE"
-		echo "DISABLE_LOGGING=true" >> "$CONF_FILE"
+		echo "DISABLE_LOGGING=false" >> "$CONF_FILE"
 	fi
 }
 
@@ -650,7 +650,7 @@ API_CALL_CONNECT_TIMEOUT_SEC=5
 API_CALL_TIMEOUT_SEC=60
 API_CALL_RETRIES=1
 
-LOG_FILE="$HOME/.${SELF}.log"
+LOG_FILE="$CONF_ROOT/log"
 
 AUTO_DELETE_DELAY=""  # if set, uploaded image(s) will be deleted after this delay
 


### PR DESCRIPTION
- Only enables logging by default for users who have not set up a config
- Log path changed from `~/.imgurbash2.log` to `~/.config/imgurbash2/log`

I don't see any harm in enabling logging by default, and I think enabling it provides an important safety net for anyone who accidentally uploads an image anonymously and forgets to save the delete hash. This is especially helpful for teiler users since uploading a desktop screenshot is very easy with it which can potentially be a privacy issue. This is coming from someone who accidentally uploaded their desktop to imgur yesterday and could've used this feature but didn't have it enabled XD.

I also changed the default log location to keep the log file out of the way.

edit: I had originally changed the logging option variable name but reverted that.  